### PR TITLE
cleanup nested if's, build expiry regex only once

### DIFF
--- a/test/domains.yaml
+++ b/test/domains.yaml
@@ -1,0 +1,3 @@
+domains:
+  - google.com
+  - apple.com


### PR DESCRIPTION
This runs for me locally

```
$ ./domain_exporter -config test/domains.yaml 
2018/02/14 11:31:11 Listening on :9203
2018/02/14 11:31:11 Domain: google.com, Days: 942, Date: 2020-09-14 04:00:00 +0000 UTC
2018/02/14 11:31:12 Domain: apple.com, Days: 1101, Date: 2021-02-20 05:00:00 +0000 UTC
^C

$ curl localhost:9203/metrics
# HELP domain_expiration Days until the WHOIS record states this domain will expire
# TYPE domain_expiration gauge
domain_expiration{domain="apple.com"} 1101
domain_expiration{domain="google.com"} 942
```