### PR TITLE
fix: .cn

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 		[]string{"domain"},
 	)
 
-	expiryRegex = regexp.MustCompile(`(?i)(Registry Expiry Date|paid-till|Expiration Date|Expiry.*|expires.*): (.*)`)
+	expiryRegex = regexp.MustCompile(`(?i)(Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry.*|expires.*): (.*)`)
 
 	formats = []string{
 		"2006-01-02",
@@ -51,6 +51,7 @@ var (
 		"2006/01/02",
 		"Mon Jan 2006 15:04:05",
 		"2006-01-02 15:04:05-07",
+		"2006-01-02 15:04:05",
 	}
 )
 


### PR DESCRIPTION
```
# whois google.cn
[Querying whois.cnnic.cn]
[whois.cnnic.cn]
Domain Name: google.cn
ROID: 20030311s10001s00033735-cn
Domain Status: clientDeleteProhibited
Domain Status: serverDeleteProhibited
Domain Status: clientUpdateProhibited
Domain Status: serverUpdateProhibited
Domain Status: clientTransferProhibited
Domain Status: serverTransferProhibited
Registrant ID: mark-135742
Registrant: Google Inc.
Registrant Contact Email: dns-admin@google.com
Sponsoring Registrar: MarkMonitor Inc.
Name Server: ns1.google.com
Name Server: ns2.google.com
Name Server: ns3.google.com
Name Server: ns4.google.com
Registration Time: 2003-03-17 12:20:05
Expiration Time: 2019-03-17 12:48:36
DNSSEC: unsigned
```