### PR TITLE
promlog.New changed signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Flags:
       --config="domains.yml"  Domain exporter configuration file.
       --bind=":9203"          The address to listen on for HTTP requests.
       --log.level=info        Only log messages with the given severity or above. One of: [debug, info, warn, error]
+      --log.format=logfmt     Output format of log messages. One of: [logfmt, json]
       --version               Show application version.
 ```
 

--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ var (
 		"2006-01-02 15:04:05",
 	}
 
-	allowedLevel promlog.AllowedLevel
-	logger       log.Logger
+	config promlog.Config
+	logger log.Logger
 )
 
 type Config struct {
@@ -70,12 +70,12 @@ type Config struct {
 }
 
 func main() {
-	flag.AddFlags(kingpin.CommandLine, &allowedLevel)
+	flag.AddFlags(kingpin.CommandLine, &config)
 	kingpin.Version(version.Print("domain_exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
-	logger = promlog.New(allowedLevel)
+	logger = promlog.New(&config)
 
 	level.Info(logger).Log("msg", "Starting domain_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())

--- a/parse_test.go
+++ b/parse_test.go
@@ -11,9 +11,15 @@ import (
 )
 
 func init() { // so we don't panic
-	level := promlog.AllowedLevel{}
-	level.Set("info")
-	logger = promlog.New(level)
+	allowedLevel := promlog.AllowedLevel{}
+	allowedLevel.Set("debug")
+	allowedFormat := promlog.AllowedFormat{}
+	allowedFormat.Set("logfmt")
+	promlogConfig := promlog.Config{
+		Level:  &allowedLevel,
+		Format: &allowedFormat,
+	}
+	logger = promlog.New(&promlogConfig)
 }
 
 func TestParsing(t *testing.T) {


### PR DESCRIPTION
Fixes invalid type being passes to the constructor:

```
cannot use &allowedLevel (type *promlog.AllowedLevel) as type *promlog.Config in argument to flag.AddFlags
```

See following for more info: https://github.com/prometheus/common/pull/136