### PR TITLE
updated regex to be able to consume .jp domains

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ var (
 		[]string{"domain"},
 	)
 
-	expiryRegex = regexp.MustCompile(`(?i)(Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry.*|expires.*|expire-date):[ \t](.*)`)
+	expiryRegex = regexp.MustCompile(`(?i)(\[有効期限]|Registry Expiry Date|paid-till|Expiration Date|Expiration Time|Expiry.*|expires.*|expire-date)[?:|\s][ \t](.*)`)
 
 	formats = []string{
 		"2006-01-02",

--- a/parse_test.go
+++ b/parse_test.go
@@ -27,6 +27,7 @@ func TestParsing(t *testing.T) {
 		date     time.Time
 	}{
 		{filename: "google.cn", date: time.Date(2019, 3, 17, 12, 48, 36, 0, time.UTC)},
+		{filename: "google.jp", date: time.Date(2021, 5, 31, 0, 0, 0, 0, time.UTC)},
 		{filename: "google.com", date: time.Date(2020, 9, 14, 4, 0, 0, 0, time.UTC)},
 		{filename: "ietf.org", date: time.Date(2020, 3, 12, 5, 0, 0, 0, time.UTC)},
 		{filename: "unisportstore.fi", date: time.Date(2019, 3, 20, 17, 13, 49, 0, time.UTC)},

--- a/testdata/google.jp
+++ b/testdata/google.jp
@@ -1,0 +1,36 @@
+[ JPRS database provides information on network administration. Its use is    ]
+[ restricted to network administration purposes. For further information,     ]
+[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+
+Domain Information: [ドメイン情報]
+[Domain Name]                   GOOGLE.JP
+
+[登録者名]                      Google LLC
+[Registrant]                    Google LLC
+
+[Name Server]                   ns1.google.com
+[Name Server]                   ns2.google.com
+[Name Server]                   ns3.google.com
+[Name Server]                   ns4.google.com
+[Signing Key]
+
+[登録年月日]                    2005/05/30
+[有効期限]                      2021/05/31
+[状態]                          Active
+[最終更新]                      2020/08/06 13:20:20 (JST)
+
+Contact Information: [公開連絡窓口]
+[名前]                          Google LLC
+[Name]                          Google LLC
+[Email]                         dns-admin@google.com
+[Web Page]
+[郵便番号]                      94043
+[住所]                          Mountain View
+                                1600 Amphitheatre Parkway
+                                CA
+[Postal Address]                Mountain View
+                                1600 Amphitheatre Parkway
+                                CA
+[電話番号]                      16502530000
+[FAX番号]                       16502530001


### PR DESCRIPTION
it will still parse other domains as per normal.

added in google.jp whois file
updated go test to use google.jp formats.
please note this is different from co.jp domains.