### PR TITLE
feat: version fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: "1.20"
 
     - name: Build
       run: go build -v ./...

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
Current [builds are pulling in go version 1.2](https://github.com/shift/domain_exporter/actions/runs/5825047473/job/15941030512#step:3:21) rather than 1.20 which may be causing the go dependency issues. These seem to be fixed after passing a string rather than a number as it stops the trailing 0 from being truncated.
 
After changing this, the kingpin module breaks with:
```
Error: ./main.go:75:16: cannot use kingpin.CommandLine (variable of type *"gopkg.in/alecthomas/kingpin.v2".Application) as *"github.com/alecthomas/kingpin/v2".Application value in argument to flag.AddFlags
``` 

Using the [correct kingpin v2 module path](https://github.com/alecthomas/kingpin#v2-is-the-current-stable-version) fixes the typing.

It seems to start ok locally:
```
$ ./domain_exporter --config="domains.yaml"
ts=2023-08-17T12:15:18.186Z caller=main.go:82 level=info msg="Starting domain_exporter" version="(version=, branch=, revision=3c440d2ef68e3edd4ae164afbae70bbb1e55d87b)"
ts=2023-08-17T12:15:18.186Z caller=main.go:83 level=info msg="Build context" (gogo1.21.0,platformdarwin/arm64,user,date,tagsunknown)=(MISSING)
ts=2023-08-17T12:15:18.186Z caller=main.go:123 level=info msg=Listening port=:9203
ts=2023-08-17T12:15:18.250Z caller=main.go:176 level=info domain:=google.com date=2028-09-14T04:00:00Z
ts=2023-08-17T12:15:18.303Z caller=main.go:110 level=warn warn="Unable to parse date: Last updated:  10-Dec-2020, for bbc.co.uk\n"
ts=2023-08-17T12:15:18.335Z caller=main.go:176 level=info domain:=ycombinator.com date=2024-03-20T22:51:07Z```
```

CI passes on a PR on the fork: https://github.com/burnjake/domain_exporter/pull/1