### PR TITLE
Add namespace to helm charts

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "domain-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "domain-exporter.labels" . | nindent 4 }}
 data:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ .Values.deployment.apiVersion | default "apps/v1" }}
 kind: Deployment
 metadata:
   name: {{ include "domain-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "domain-exporter.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "domain-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "domain-exporter.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "domain-exporter.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "domain-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "domain-exporter.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "domain-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "domain-exporter.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Kustomize 5.8.0 no longer add namespaces to resources in helm charts without explicit namespace.

E.g. you used to be able have a kustomization.yaml like this, and the kustomization would apply cleanly.

```yaml
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: monitoring    # <- this used to set the namespace of all resources to `monitoring`, but no longer runs on the output of helmCharts

helmCharts:
  - name: domain-exporter
    repo: https://shift.github.io/domain_exporter/
    version: 0.0.8
    releaseName: domain-exporter
    namespace: monitoring    # <- this sets .Release.Namespace
    includeCRDs: true
    skipTests: true
    valuesFile: values.yaml
```

After updating to Kustomize 5.8.0, these resources will not get a namespace unless it is added to the helm chart.  This is the only chart we use that has this issue.

### Links

* https://github.com/kubernetes-sigs/kustomize/issues/6058

### Other workarounds

* Add kustomize `patches` to patch namespaces onto to all of these resources.
* Give up on kustomize and use `helm` directly