### PR TITLE
fix: use current WHOIS server for .co domains

### DIFF
--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func parse(host string, res []byte) (float64, error) {
 }
 
 func lookup(domain string, handler *prometheus.GaugeVec, parsedExpiration *prometheus.GaugeVec) (float64, error) {
-	req, err := whois.NewRequest(domain)
+	req, err := requestForDomain(domain)
 	if err != nil {
 		return -1, err
 	}
@@ -210,4 +210,20 @@ func lookup(domain string, handler *prometheus.GaugeVec, parsedExpiration *prome
 	}
 
 	return date, nil
+}
+
+func requestForDomain(domain string) (*whois.Request, error) {
+	req := &whois.Request{Query: domain}
+
+	// .co moved its WHOIS service from whois.nic.co to whois.registry.co.
+	// Set the host before preparing the request so the generic WHOIS adapter
+	// constructs the request for the current registry endpoint.
+	if strings.HasSuffix(strings.ToLower(strings.TrimSuffix(domain, ".")), ".co") {
+		req.Host = "whois.registry.co"
+	}
+
+	if err := req.Prepare(); err != nil {
+		return nil, err
+	}
+	return req, nil
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -59,3 +59,14 @@ func TestParsing(t *testing.T) {
 		}
 	}
 }
+
+func TestRequestForCOUsesCurrentRegistryWHOISServer(t *testing.T) {
+	req, err := requestForDomain("example.co")
+	if err != nil {
+		t.Fatalf("requestForDomain returned an error: %v", err)
+	}
+
+	if got, want := req.Host, "whois.registry.co"; got != want {
+		t.Errorf("request host = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
  ## Summary

  Fix `.co` domain WHOIS lookups by using `whois.registry.co`.

  ## Background

  The previous `.co` WHOIS endpoint, `whois.nic.co`, no longer resolves. This prevents the exporter from collecting expiry metrics for `.co` domains.

  ## Changes

  - Use `whois.registry.co` for `.co` domains before preparing the WHOIS request.
  - Preserve existing behavior for every other TLD.
  - Add regression coverage for `.co` request-host selection.

  ## Request

  Please review and consider publishing a new container image release after merge.